### PR TITLE
update peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dropdown"
   ],
   "peerDependencies": {
-    "react-native": "^0.11.4"
+    "react-native": ">=0.11.4"
   },
   "author": "Do Anh Tu <chymtt@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Ran into an issue with the peerDependencies when trying to use this package with the latest 0.12.0 release of react-native. This PR tweaks the peer deps so that 0.12.0 can be valid.
